### PR TITLE
Simple logging: added logging capability

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -106,7 +106,7 @@ func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) error 
 	if err := writer.Close(); err != nil {
 		return errors.Wrap(err, "close writer")
 	}
-	c.logf(">> vars:%+v files:%d query:%q", req.vars, len(req.files), req.q)
+	c.logf(">> vars:%+v files:%d query:%s", req.vars, len(req.files), req.q)
 	var graphResponse = struct {
 		Data   interface{}
 		Errors []graphErr

--- a/graphql.go
+++ b/graphql.go
@@ -34,6 +34,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -45,12 +46,15 @@ import (
 type Client struct {
 	endpoint   string
 	httpClient *http.Client
+
+	Log func(s string)
 }
 
 // NewClient makes a new Client capable of making GraphQL requests.
 func NewClient(endpoint string, opts ...ClientOption) *Client {
 	c := &Client{
 		endpoint: endpoint,
+		Log:      func(string) {},
 	}
 	for _, optionFunc := range opts {
 		optionFunc(c)
@@ -59,6 +63,10 @@ func NewClient(endpoint string, opts ...ClientOption) *Client {
 		c.httpClient = http.DefaultClient
 	}
 	return c
+}
+
+func (c *Client) logf(format string, args ...interface{}) {
+	c.Log(fmt.Sprintf(format, args...))
 }
 
 // Run executes the query and unmarshals the response from the data field
@@ -98,6 +106,7 @@ func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) error 
 	if err := writer.Close(); err != nil {
 		return errors.Wrap(err, "close writer")
 	}
+	c.logf(">> vars:%+v files:%d query:%q", req.vars, len(req.files), req.q)
 	var graphResponse = struct {
 		Data   interface{}
 		Errors []graphErr
@@ -120,6 +129,7 @@ func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) error 
 	if _, err := io.Copy(&buf, res.Body); err != nil {
 		return errors.Wrap(err, "reading body")
 	}
+	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&graphResponse); err != nil {
 		return errors.Wrap(err, "decoding response")
 	}


### PR DESCRIPTION
You just set a function like this:

```go
c := NewClient(...)
c.Log = func(s string) { log.Println(s) }
```