### PR TITLE
added header customizability to graphql.Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Low-level GraphQL client for Go.
 * Use variables and upload files
 * Simple error handling
 
+## Installation
+Make sure you have a working Go environment. To install graphql, simply run:
+
+```
+$ go get github.com/machinebox/graphql
+```
+
+## Usage
+
 ```go
 import "context"
 
@@ -28,6 +37,9 @@ req := graphql.NewRequest(`
 
 // set any variables
 req.Var("key", "value")
+
+// set header fields
+req.Header.Set("Cache-Control", "no-cache")
 
 // define a Context for the request
 ctx := context.Background()

--- a/graphql.go
+++ b/graphql.go
@@ -178,9 +178,29 @@ type graphResponse struct {
 
 // Request is a GraphQL request.
 type Request struct {
-	q      string
-	vars   map[string]interface{}
-	files  []file
+	q     string
+	vars  map[string]interface{}
+	files []file
+
+	// Header mirrors the Header of a http.Request. It contains
+	// the request header fields either received
+	// by the server or to be sent by the client.
+	//
+	// If a server received a request with header lines,
+	//
+	//  Host: example.com
+	//  accept-encoding: gzip, deflate
+	//  Accept-Language: en-us
+	//  fOO: Bar
+	//  foo: two
+	//
+	// then
+	//
+	//  Header = map[string][]string{
+	//    "Accept-Encoding": {"gzip, deflate"},
+	//    "Accept-Language": {"en-us"},
+	//    "Foo": {"Bar", "two"},
+	//  }
 	Header Header
 }
 

--- a/graphql.go
+++ b/graphql.go
@@ -38,6 +38,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 
 	"github.com/pkg/errors"
 )
@@ -122,6 +123,12 @@ func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) error 
 	}
 	r.Header.Set("Content-Type", writer.FormDataContentType())
 	r.Header.Set("Accept", "application/json")
+	for key, values := range req.Header {
+		for _, value := range values {
+			r.Header.Add(key, value)
+		}
+	}
+	c.logf(">> headers: %v", r.Header)
 	r = r.WithContext(ctx)
 	res, err := c.httpClient.Do(r)
 	if err != nil {
@@ -171,15 +178,17 @@ type graphResponse struct {
 
 // Request is a GraphQL request.
 type Request struct {
-	q     string
-	vars  map[string]interface{}
-	files []file
+	q      string
+	vars   map[string]interface{}
+	files  []file
+	Header Header
 }
 
 // NewRequest makes a new Request with the specified string.
 func NewRequest(q string) *Request {
 	req := &Request{
-		q: q,
+		q:      q,
+		Header: make(map[string][]string),
 	}
 	return req
 }
@@ -199,6 +208,37 @@ func (req *Request) File(fieldname, filename string, r io.Reader) {
 		Name:  filename,
 		R:     r,
 	})
+}
+
+// A Header represents the key-value pairs in an HTTP header.
+type Header map[string][]string
+
+// Add adds the key, value pair to the header.
+// It appends to any existing values associated with key.
+func (h Header) Add(key, value string) {
+	textproto.MIMEHeader(h).Add(key, value)
+}
+
+// Set sets the header entries associated with key to
+// the single element value. It replaces any existing
+// values associated with key.
+func (h Header) Set(key, value string) {
+	textproto.MIMEHeader(h).Set(key, value)
+}
+
+// Get gets the first value associated with the given key.
+// It is case insensitive; textproto.CanonicalMIMEHeaderKey is used
+// to canonicalize the provided key.
+// If there are no values associated with the key, Get returns "".
+// To access multiple values of a key, or to use non-canonical keys,
+// access the map directly.
+func (h Header) Get(key string) string {
+	return textproto.MIMEHeader(h).Get(key)
+}
+
+// Del deletes the values associated with key.
+func (h Header) Del(key string) {
+	textproto.MIMEHeader(h).Del(key)
 }
 
 // file represents a file to upload.


### PR DESCRIPTION
This PR gives developers the ability to add their own headers to a `graphql.Request`. The `graphql.Request.Header` mirrors the Header of a `http.Request`. It contains the request header fields sent by the client.

If a server received a request with header lines,
```
Host: example.com
accept-encoding: gzip, deflate
Accept-Language: en-us
fOO: Bar
foo: two
```
then
```
Header = map[string][]string{
  "Accept-Encoding": {"gzip, deflate"},
  "Accept-Language": {"en-us"},
  "Foo": {"Bar", "two"},
}