### PR TITLE
Add retry policy for graqhql client

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,62 @@
+package graphql
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+const (
+	errNotFound           graphErrType = "not_found"
+	errNotAllowed         graphErrType = "not_allowed"
+	errInvalidInput       graphErrType = "invalid_input"
+	errCapacityExceeded   graphErrType = "capacity_exceeded"
+	errAuthentication     graphErrType = "authentication_error"
+	errImplemented        graphErrType = "not_implemented"
+	errServiceUnavailable graphErrType = "service_unavailable"
+	errServiceFailure     graphErrType = "service_failure"
+	errInternal           graphErrType = "internal_error"
+)
+
+type graphErr struct {
+	Message    string        `json:"message,omitempty"`
+	Name       graphErrType  `json:"name,omitempty"`
+	TimeThrown string        `json:"time_thrown,omitempty"`
+	Data       interface{}   `json:"data,omitempty"`
+	Path       []string      `json:"path,omitempty"`
+	Locations  []graphErrLoc `json:"locations,omitempty"`
+}
+
+type graphErrData struct {
+	ObjectID   string `json:"objectId,omitempty"`
+	ObjectType string `json:"objectType,omitempty"`
+	ErrorID    string `json:"errorId,omitempty"`
+	RequestID  string `json:"requestId,omitempty"`
+}
+
+type graphErrLoc struct {
+	Line   int64 `json:"line"`
+	Column int64 `json:"column"`
+}
+
+type graphErrType string
+
+func getAggrErr(errList []graphErr) error {
+	var buffer bytes.Buffer
+	buffer.WriteString("graphql: ")
+	for idx, err := range errList {
+		buffer.WriteString(fmt.Sprintf("error %d: message (%s), data (%+v). ", idx, err.Message, err.Data))
+	}
+
+	return errors.New(buffer.String())
+}
+
+func shouldRetry(errList []graphErr) bool {
+	for _, err := range errList {
+		if err.Name == errCapacityExceeded || err.Name == errServiceUnavailable || err.Name == errServiceFailure || err.Name == errInternal {
+			return true
+		}
+	}
+
+	return false
+}

--- a/error.go
+++ b/error.go
@@ -23,7 +23,7 @@ type graphErr struct {
 	Name       graphErrType  `json:"name,omitempty"`
 	TimeThrown string        `json:"time_thrown,omitempty"`
 	Data       interface{}   `json:"data,omitempty"`
-	Path       []string      `json:"path,omitempty"`
+	Path       []interface{} `json:"path,omitempty"`
 	Locations  []graphErrLoc `json:"locations,omitempty"`
 }
 

--- a/graphql.go
+++ b/graphql.go
@@ -377,7 +377,6 @@ func (c *Client) executeRequest(gr *graphResponse, r *http.Request) error {
 				}
 
 			} else {
-				// return first error
 				c.Log("debug return error")
 				return getAggrErr(gr.Errors)
 			}

--- a/graphql.go
+++ b/graphql.go
@@ -212,6 +212,13 @@ func WithDefaultExponentialRetryConfig() ClientOption {
 	}
 }
 
+// WithBeforeRetryHandler provides a handler for beforeRetry
+func WithBeforeRetryHandler(beforeRetryHandler func(*http.Request, *http.Response, int)) ClientOption {
+	return func(client *Client) {
+		client.retryConfig.BeforeRetry = beforeRetryHandler
+	}
+}
+
 // Run executes the query and unmarshals the response from the data field
 // into the response object.
 // Pass in a nil response object to skip response parsing.

--- a/graphql.go
+++ b/graphql.go
@@ -51,6 +51,7 @@ type Client struct {
 	httpClient       *http.Client
 	useMultipartForm bool
 	retryConfig      RetryConfig
+	defaultHeaders   map[string]string
 
 	// Log is called with various debug information.
 	// To log to standard out, use:
@@ -230,6 +231,13 @@ func WithBeforeRetryHandler(beforeRetryHandler func(*http.Request, *http.Respons
 	}
 }
 
+// WithDefaultHeaders provides a default set of header values
+func WithDefaultHeaders(defaultHeaders map[string]string) ClientOption {
+	return func(client *Client) {
+		client.defaultHeaders = defaultHeaders
+	}
+}
+
 // Run executes the query and unmarshals the response from the data field
 // into the response object.
 // Pass in a nil response object to skip response parsing.
@@ -275,6 +283,9 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	}
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
 	r.Header.Set("Accept", "application/json; charset=utf-8")
+	for key, value := range c.defaultHeaders {
+		r.Header.Add(key, value)
+	}
 	for key, values := range req.Header {
 		for _, value := range values {
 			r.Header.Add(key, value)
@@ -342,6 +353,9 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	}
 	r.Header.Set("Content-Type", writer.FormDataContentType())
 	r.Header.Set("Accept", "application/json; charset=utf-8")
+	for key, value := range c.defaultHeaders {
+		r.Header.Add(key, value)
+	}
 	for key, values := range req.Header {
 		for _, value := range values {
 			r.Header.Add(key, value)

--- a/graphql.go
+++ b/graphql.go
@@ -109,7 +109,7 @@ var (
 	}
 
 	defaultExponentialRetryConfig = RetryConfig{
-		MaxTries:    4,
+		MaxTries:    5,
 		Interval:    1,
 		Policy:      ExponentialBackoff,
 		MaxInterval: 16,

--- a/graphql.go
+++ b/graphql.go
@@ -149,6 +149,7 @@ func (c *Client) sendRequest(retryConfig *RetryConfig, req *http.Request) (*http
 		// Assign request body for new request before retry with a temp buf
 		buf := new(bytes.Buffer)
 		req.Body = ioutil.NopCloser(io.TeeReader(body, buf))
+		c.logf("body buffer: %s", buf.String())
 
 		if req.Context().Err() == context.Canceled {
 			return nil, context.Canceled

--- a/graphql.go
+++ b/graphql.go
@@ -288,7 +288,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	}
 	c.logf(">> headers: %v", r.Header)
 	r = r.WithContext(ctx)
-	res, err := c.httpClient.Do(r)
+	res, err := c.sendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/graphql.go
+++ b/graphql.go
@@ -91,7 +91,7 @@ type RetryConfig struct {
 	// If not specifed, we will use default retry behavior on certain statuses
 	RetryStatus map[int]bool `json:"statusToRetry"`
 	// Client can use this function to supply some logic to further debug GraphQL request & response
-	BeforeRetry func(req *http.Request, resp *http.Response, attemptNum int)
+	BeforeRetry func(req *http.Request, resp *http.Response, err error, attemptNum int)
 }
 
 // PolicyType defines a type of different possible Policies to be applied towards retrying
@@ -121,15 +121,10 @@ var (
 
 // Wrapper method to send request while optionally applying retry policy
 func (c *Client) sendRequest(req *http.Request) (*http.Response, error) {
-	var (
-		resp *http.Response
-		err  error
-	)
-
 	retryConfig := c.retryConfig
 	// Client did not specify retry config
 	if retryConfig.Policy == "" {
-		resp, err = c.httpClient.Do(req)
+		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			return resp, fmt.Errorf("Error getting response: %v", err)
 		}
@@ -137,16 +132,17 @@ func (c *Client) sendRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	c.logf("debug original request: %+v", req)
+
 	// Persist request body
 	var body io.Reader = req.Body
-	for tryCount := 0; tryCount < retryConfig.MaxTries; tryCount++ {
-
+	tryCount := 0
+	for ; tryCount < retryConfig.MaxTries; tryCount++ {
 		// Assign request body for new request before retry with a temp buf
 		buf := new(bytes.Buffer)
 		req.Body = ioutil.NopCloser(io.TeeReader(body, buf))
 
 		c.logf("debug request: %+v", req)
-		resp, err = c.httpClient.Do(req)
+		resp, err := c.httpClient.Do(req)
 		c.logf("debug response: %+v", resp)
 
 		if err == nil && !retryConfig.shouldRetry(resp.StatusCode) {
@@ -157,7 +153,7 @@ func (c *Client) sendRequest(req *http.Request) (*http.Response, error) {
 		body = buf
 
 		if retryConfig.BeforeRetry != nil {
-			retryConfig.BeforeRetry(req, resp, tryCount+1)
+			retryConfig.BeforeRetry(req, resp, err, tryCount+1)
 		}
 
 		c.Log("Will retry after interval expires")
@@ -177,10 +173,9 @@ func (c *Client) sendRequest(req *http.Request) (*http.Response, error) {
 			retryConfig.increaseInterval()
 			c.logf("New interval: %f", retryConfig.Interval)
 		}
-
 	}
 
-	return nil, fmt.Errorf("Error getting response with retry: %s", err)
+	return nil, fmt.Errorf("Client has retried %d times but unable to get a successful response", tryCount)
 }
 
 // Increase interval for exponential backoff policy until hitting MaxInterval
@@ -229,7 +224,7 @@ func WithDefaultExponentialRetryConfig() ClientOption {
 }
 
 // WithBeforeRetryHandler provides a handler for beforeRetry
-func WithBeforeRetryHandler(beforeRetryHandler func(*http.Request, *http.Response, int)) ClientOption {
+func WithBeforeRetryHandler(beforeRetryHandler func(*http.Request, *http.Response, error, int)) ClientOption {
 	return func(client *Client) {
 		client.retryConfig.BeforeRetry = beforeRetryHandler
 	}

--- a/graphql.go
+++ b/graphql.go
@@ -161,9 +161,11 @@ func (c *Client) sendRequest(retryConfig *RetryConfig, req *http.Request) (*http
 		if err != nil && !isErrRetryable(err) {
 			return resp, err
 		}
-		statusCode = resp.StatusCode
-		if err == nil && !retryConfig.shouldRetry(statusCode) {
-			return resp, err
+		if err == nil {
+			statusCode = resp.StatusCode
+			if !retryConfig.shouldRetry(statusCode) {
+				return resp, err
+			}
 		}
 
 		// Assign buf back to body

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -71,11 +71,9 @@ func TestDoErr(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
-			"errors": [{
-				"message": "Something went wrong"
-			}]
-		}`)
+		resp, err := ioutil.ReadFile("resources/unknown.json")
+		is.NoErr(err)
+		w.Write(resp)
 	}))
 	defer srv.Close()
 
@@ -87,7 +85,7 @@ func TestDoErr(t *testing.T) {
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
 	is.True(err != nil)
-	is.Equal(err.Error(), "graphql: Something went wrong")
+	is.Equal(err.Error(), "graphql: error 0: message (Something went wrong), data (test). ")
 }
 
 func TestDoNoResponse(t *testing.T) {

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -40,6 +40,25 @@ func TestLinearPolicy(t *testing.T) {
 	}
 }
 
+func TestNilRespStatus200(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, WithDefaultLinearRetryConfig())
+	client.Log = func(str string) {
+		t.Log(str)
+	}
+
+	var responseData map[string]interface{}
+	err := client.Run(context.Background(), &Request{q: "query {}"}, &responseData)
+	is.NoErr(err)
+}
+
 func TestNoPolicySpecified(t *testing.T) {
 	t.Parallel()
 	is := is.New(t)

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -107,12 +107,17 @@ func TestExponentialBackoffPolicy(t *testing.T) {
 	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
+		w.WriteHeader(http.StatusBadGateway)
 	}))
 	defer srv.Close()
 
 	ctx := context.Background()
 	client := NewClient(srv.URL, WithDefaultExponentialRetryConfig())
+	client.retryConfig.BeforeRetry = func(req *http.Request, resp *http.Response, attemptCount int) {
+		t.Logf("Retrying request: %+v", req)
+		t.Logf("Retrying after last response: %+v", resp)
+		t.Logf("Retrying attempt count: %d", attemptCount)
+	}
 	client.Log = func(str string) {
 		t.Log(str)
 	}

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -18,6 +18,7 @@ func getTestDuration(sec int) time.Duration {
 }
 
 func TestLinearPolicy(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -40,6 +41,7 @@ func TestLinearPolicy(t *testing.T) {
 }
 
 func TestNoPolicySpecified(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -71,6 +73,7 @@ func TestNoPolicySpecified(t *testing.T) {
 }
 
 func TestCustomRetryStatus(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -101,6 +104,7 @@ func TestCustomRetryStatus(t *testing.T) {
 }
 
 func TestExponentialBackoffPolicy(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -113,7 +117,7 @@ func TestExponentialBackoffPolicy(t *testing.T) {
 		t.Log(str)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, getTestDuration(16))
+	ctx, cancel := context.WithTimeout(ctx, getTestDuration(31))
 	defer cancel()
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -16,7 +16,7 @@ import (
 func TestLinearPolicy(t *testing.T) {
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
@@ -41,7 +41,7 @@ func TestLinearPolicy(t *testing.T) {
 func TestNoPolicySpecified(t *testing.T) {
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusServiceUnavailable)
 
 		is.Equal(r.Method, http.MethodPost)
 		b, err := ioutil.ReadAll(r.Body)
@@ -99,7 +99,7 @@ func TestCustomRetryStatus(t *testing.T) {
 func TestExponentialBackoffPolicy(t *testing.T) {
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -1,0 +1,123 @@
+package graphql
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func TestLinearPolicy(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryConfig := RetryConfig{
+		Policy:      Linear,
+		MaxTries:    3,
+		Interval:    1,
+		MaxInterval: 10,
+	}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	if !strings.HasPrefix(err.Error(), "Error getting response with retry:") {
+		is.Fail()
+	}
+}
+
+func TestNoPolicySpecified(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+
+		is.Equal(r.Method, http.MethodPost)
+		b, err := ioutil.ReadAll(r.Body)
+		is.NoErr(err)
+		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
+		io.WriteString(w, `{
+			"data": {
+				"something": "yes"
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryConfig := RetryConfig{}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	is.NoErr(err)
+	is.Equal(responseData["something"], "yes")
+}
+
+func TestCustomRetryStatus(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryStatus := make(map[int]bool)
+	retryStatus[http.StatusOK] = true
+	retryConfig := RetryConfig{
+		Policy:      Linear,
+		MaxTries:    3,
+		Interval:    1,
+		MaxInterval: 10,
+		RetryStatus: retryStatus,
+	}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	t.Logf("error: %s", err)
+	if !strings.HasPrefix(err.Error(), "Error getting response with retry:") {
+		is.Fail()
+	}
+}
+
+func TestExponentialBackoffPolicy(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryConfig := RetryConfig{
+		Policy:      ExponentialBackoff,
+		MaxTries:    3,
+		Interval:    1,
+		MaxInterval: 10,
+	}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	t.Logf("error: %s", err)
+	if !strings.HasPrefix(err.Error(), "Error getting response with retry:") {
+		is.Fail()
+	}
+}

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -173,3 +173,9 @@ func TestExponentialBackoffPolicyMultiPart(t *testing.T) {
 		is.Fail()
 	}
 }
+
+func TestIsErrRetryableNil(t *testing.T) {
+	is := is.New(t)
+	flag := isErrRetryable(nil)
+	is.True(!flag)
+}

--- a/resources/capacity_exceeded.json
+++ b/resources/capacity_exceeded.json
@@ -1,0 +1,47 @@
+{
+    "data": {
+        "query": null
+    },
+    "errors": [
+        {
+            "message": "Requested object was not found",
+            "name": "capacity_exceeded",
+            "data": {
+                "serviceMessage": "Invalid taskStatus value",
+                "requestId": "0A0B0140:9A22_0A0B66AA:0050_5BD24F0C_1ADE258D:7651",
+                "errorCode": "invalidTaskStatus",
+                "details": {
+                  "input": "aborted",
+                  "allowedStatus": [
+                    "running",
+                    "complete",
+                    "failed",
+                    "queued",
+                    "waiting"
+                  ]
+                },
+                "errorId": "cab2287e-e1b0-4bf1-aebc-ccef9fe2fed8"
+            }
+        }, 
+        {
+            "message": "Requested object was not found",
+            "name": "capacity_exceeded",
+            "data": {
+                "serviceMessage": "Invalid taskStatus value",
+                "requestId": "0A0B0140:9A22_0A0B66AA:0050_5BD24F0C_1ADE258D:7652",
+                "errorCode": "invalidTaskStatus",
+                "details": {
+                  "input": "aborted",
+                  "allowedStatus": [
+                    "running",
+                    "complete",
+                    "failed",
+                    "queued",
+                    "waiting"
+                  ]
+                },
+                "errorId": "cab2287e-e1b0-4bf1-aebc-ccef9fe2fed8"
+            }
+        }
+    ]
+}

--- a/resources/not_found.json
+++ b/resources/not_found.json
@@ -1,0 +1,47 @@
+{
+    "data": {
+        "query": null
+    },
+    "errors": [
+        {
+            "message": "Requested object was not found",
+            "name": "not_found",
+            "data": {
+                "serviceMessage": "Invalid taskStatus value",
+                "requestId": "0A0B0140:9A22_0A0B66AA:0050_5BD24F0C_1ADE258D:7651",
+                "errorCode": "invalidTaskStatus",
+                "details": {
+                  "input": "aborted",
+                  "allowedStatus": [
+                    "running",
+                    "complete",
+                    "failed",
+                    "queued",
+                    "waiting"
+                  ]
+                },
+                "errorId": "cab2287e-e1b0-4bf1-aebc-ccef9fe2fed8"
+            }
+        },
+        {
+            "message": "Requested object was not found",
+            "name": "not_found",
+            "data": {
+                "serviceMessage": "Invalid taskStatus value",
+                "requestId": "0A0B0140:9A22_0A0B66AA:0050_5BD24F0C_1ADE258D:7651",
+                "errorCode": "invalidTaskStatus",
+                "details": {
+                  "input": "aborted",
+                  "allowedStatus": [
+                    "running",
+                    "complete",
+                    "failed",
+                    "queued",
+                    "waiting"
+                  ]
+                },
+                "errorId": "cab2287e-e1b0-4bf1-aebc-ccef9fe2fed8"
+            }
+        }
+    ]
+}

--- a/resources/not_found.json
+++ b/resources/not_found.json
@@ -21,7 +21,19 @@
                   ]
                 },
                 "errorId": "cab2287e-e1b0-4bf1-aebc-ccef9fe2fed8"
-            }
+            },
+            "path": [
+                "scheduledJobs",
+                "records",
+                32,
+                "primarySource"
+              ],
+            "locations": [
+                {
+                    "line": 11,
+                    "column": 7
+                }
+            ]
         },
         {
             "message": "Requested object was not found",
@@ -41,7 +53,19 @@
                   ]
                 },
                 "errorId": "cab2287e-e1b0-4bf1-aebc-ccef9fe2fed8"
-            }
+            },
+            "path": [
+                "scheduledJobs",
+                "records",
+                32,
+                "primarySource"
+              ],
+            "locations": [
+                {
+                    "line": 11,
+                    "column": 7
+                }
+            ]
         }
     ]
 }

--- a/resources/unknown.json
+++ b/resources/unknown.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+        {
+            "message": "Something went wrong",
+            "data": "test"
+        }
+    ]
+}


### PR DESCRIPTION
## Background
Often times, we need to retry graphql request in case of transient network issue. This change aims to add that retry capabilities if the library consumers want to.

## Overview
* This Pull Request aims to add 2 retry policies for the graphql client:
  * `LinearPolicy`
  * `ExponentialBackoffPolicy`
* Included unit test to test the new change

## Test
* Added unit test & passed.