### PR TITLE
8 - Provide clearer error for non-200 status codes without JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
   - 1.10.x
 
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
 
 before_script:
   - go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 before_install:
   - go get github.com/golang/lint/golint

--- a/graphql.go
+++ b/graphql.go
@@ -42,6 +42,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const errorNon200Template = "graphql: server returned a non-200 status code: %v"
+
 // Client is a client for interacting with a GraphQL API.
 type Client struct {
 	endpoint         string
@@ -134,6 +136,9 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
+		if res.StatusCode != http.StatusOK {
+			return fmt.Errorf(errorNon200Template, res.StatusCode)
+		}
 		return errors.Wrap(err, "decoding response")
 	}
 	if len(gr.Errors) > 0 {
@@ -201,6 +206,9 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
+		if res.StatusCode != http.StatusOK {
+			return fmt.Errorf(errorNon200Template, res.StatusCode)
+		}
 		return errors.Wrap(err, "decoding response")
 	}
 	if len(gr.Errors) > 0 {

--- a/graphql.go
+++ b/graphql.go
@@ -42,8 +42,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const errorNon200Template = "graphql: server returned a non-200 status code: %v"
-
 // Client is a client for interacting with a GraphQL API.
 type Client struct {
 	endpoint         string
@@ -137,7 +135,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
 		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf(errorNon200Template, res.StatusCode)
+			return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
 		}
 		return errors.Wrap(err, "decoding response")
 	}
@@ -207,7 +205,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
 		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf(errorNon200Template, res.StatusCode)
+			return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
 		}
 		return errors.Wrap(err, "decoding response")
 	}

--- a/graphql_json_test.go
+++ b/graphql_json_test.go
@@ -41,6 +41,60 @@ func TestDoJSON(t *testing.T) {
 	is.Equal(responseData["something"], "yes")
 }
 
+func TestDoJSONServerError(t *testing.T) {
+	is := is.New(t)
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		is.Equal(r.Method, http.MethodPost)
+		b, err := ioutil.ReadAll(r.Body)
+		is.NoErr(err)
+		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, `Internal Server Error`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	client := NewClient(srv.URL)
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	is.Equal(calls, 1) // calls
+	is.Equal(err.Error(), "graphql: server returned a non-200 status code: 500")
+}
+
+func TestDoJSONBadRequestErr(t *testing.T) {
+	is := is.New(t)
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		is.Equal(r.Method, http.MethodPost)
+		b, err := ioutil.ReadAll(r.Body)
+		is.NoErr(err)
+		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, `{
+			"errors": [{
+				"message": "miscellaneous message as to why the the request was bad"
+			}]
+		}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	client := NewClient(srv.URL)
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	is.Equal(calls, 1) // calls
+	is.Equal(err.Error(), "graphql: miscellaneous message as to why the the request was bad")
+}
+
 func TestQueryJSON(t *testing.T) {
 	is := is.New(t)
 


### PR DESCRIPTION
# What
- This adds a check for a non-200 status code if there's a failure to unmarshal the response from the server.
-  Added tests to confirm the current behavior of returning the first error in the index if it is able to parse the response.

machinebox#8