### PR TITLE
immediately close req body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+.idea/

--- a/graphql.go
+++ b/graphql.go
@@ -48,6 +48,9 @@ type Client struct {
 	httpClient       *http.Client
 	useMultipartForm bool
 
+	//closeReq will close the request body immediately allowing for reuse of client
+	closeReq bool
+
 	// Log is called with various debug information.
 	// To log to standard out, use:
 	//  client.Log = func(s string) { log.Println(s) }
@@ -114,6 +117,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	if err != nil {
 		return err
 	}
+	r.Close = c.closeReq
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
 	r.Header.Set("Accept", "application/json; charset=utf-8")
 	for key, values := range req.Header {
@@ -184,6 +188,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	if err != nil {
 		return err
 	}
+	r.Close = c.closeReq
 	r.Header.Set("Content-Type", writer.FormDataContentType())
 	r.Header.Set("Accept", "application/json; charset=utf-8")
 	for key, values := range req.Header {
@@ -233,6 +238,12 @@ func UseMultipartForm() ClientOption {
 	}
 }
 
+//ImmediatelyCloseReqBody will close the req body immediately after each request body is ready
+func ImmediatelyCloseReqBody() ClientOption{
+	return func(client *Client) {
+		client.closeReq = true
+	}
+}
 // ClientOption are functions that are passed into NewClient to
 // modify the behaviour of the Client.
 type ClientOption func(*Client)


### PR DESCRIPTION
add the option to immediately close the req body in order for the req client to re usable with high number of conccurent request

https://stackoverflow.com/questions/17714494/golang-http-request-results-in-eof-errors-when-making-multiple-requests-successi
