### PR TITLE
Add support for error extensions

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -250,11 +250,16 @@ func ImmediatelyCloseReqBody() ClientOption {
 type ClientOption func(*Client)
 
 type graphErr struct {
-	Message string
+	Message         string
+	ErrorExtensions map[string]interface{} `json:"extensions"`
 }
 
 func (e graphErr) Error() string {
 	return "graphql: " + e.Message
+}
+
+func (e graphErr) Extensions() map[string]interface{} {
+	return e.ErrorExtensions
 }
 
 type graphResponse struct {


### PR DESCRIPTION
This commit:
 - adds an ErrorExtensions attr to the graphErr type
 - adds an Extensions method to the graphErr type

Why?
 - This adds support for error extensions as described in a
 recent(ish)  update to the [graphql spec](https://facebook.github.io/graphql/June2018/#example-fce18).
 The interface changes are minimally invasive, and are in fact
 invisible unless the importing code defines an interface that
 includes the `Extensions()` method.

An example usage:

```go
package foo

import "github.com/machinebox/graphql"

type extendedError interface {
	Extensions() map[string]interface{}
	Error() string
}

func bar() {
   client := graphql.NewClient(...)
   //...
   err := c.client.Run(ctx, req, resp)
   if ok := err.(extendedError); ok {
       extMsg, _ := json.Marshal(ee.Extensions())
       fmt.Println(extMsg)
      // prints out the extensions, e.g.:
      //{
      //  "message": "Name for character with ID 1002 could not be fetched.",
      //  "locations": [ { "line": 6, "column": 7 } ],
      //  "path": [ "hero", "heroFriends", 1, "name" ],
      //  "code": "CAN_NOT_FETCH_BY_ID",
      //  "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
      //}
   }
}

```