### PR TITLE
Use an interface so that the library works with custom HTTP clients

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -45,7 +45,7 @@ import (
 // Client is a client for interacting with a GraphQL API.
 type Client struct {
 	endpoint         string
-	httpClient       *http.Client
+	httpClient       HTTPDo
 	useMultipartForm bool
 
 	// closeReq will close the request body immediately allowing for reuse of client
@@ -55,6 +55,10 @@ type Client struct {
 	// To log to standard out, use:
 	//  client.Log = func(s string) { log.Println(s) }
 	Log func(s string)
+}
+
+type HTTPDo interface {
+	Do(*http.Request) (*http.Response, error)
 }
 
 // NewClient makes a new Client capable of making GraphQL requests.
@@ -224,7 +228,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 // WithHTTPClient specifies the underlying http.Client to use when
 // making requests.
 //  NewClient(endpoint, WithHTTPClient(specificHTTPClient))
-func WithHTTPClient(httpclient *http.Client) ClientOption {
+func WithHTTPClient(httpclient HTTPDo) ClientOption {
 	return func(client *Client) {
 		client.httpClient = httpclient
 	}

--- a/graphql_json_test.go
+++ b/graphql_json_test.go
@@ -21,7 +21,7 @@ func TestDoJSON(t *testing.T) {
 		b, err := ioutil.ReadAll(r.Body)
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
@@ -51,7 +51,7 @@ func TestDoJSONServerError(t *testing.T) {
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
 		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, `Internal Server Error`)
+		_, _ = io.WriteString(w, `Internal Server Error`)
 	}))
 	defer srv.Close()
 
@@ -76,7 +76,7 @@ func TestDoJSONBadRequestErr(t *testing.T) {
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "miscellaneous message as to why the the request was bad"
 			}]
@@ -118,7 +118,7 @@ func TestQueryJSON(t *testing.T) {
 
 	// check variables
 	is.True(req != nil)
-	is.Equal(req.vars["username"], "matryer")
+	is.Equal(req.vars["username"], "matryer") // nolint: staticcheck
 
 	var resp struct {
 		Value string

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -30,7 +30,7 @@ func TestWithClient(t *testing.T) {
 	client := NewClient("", WithHTTPClient(testClient), UseMultipartForm())
 
 	req := NewRequest(``)
-	client.Run(ctx, req, nil)
+	_ = client.Run(ctx, req, nil)
 
 	is.Equal(calls, 1) // calls
 }
@@ -43,7 +43,7 @@ func TestDoUseMultipartForm(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
@@ -70,7 +70,7 @@ func TestImmediatelyCloseReqBody(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
@@ -98,7 +98,7 @@ func TestDoErr(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "Something went wrong"
 			}]
@@ -126,7 +126,7 @@ func TestDoServerErr(t *testing.T) {
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
 		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, `Internal Server Error`)
+		_, _ = io.WriteString(w, `Internal Server Error`)
 	}))
 	defer srv.Close()
 
@@ -149,7 +149,7 @@ func TestDoBadRequestErr(t *testing.T) {
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "miscellaneous message as to why the the request was bad"
 			}]
@@ -175,7 +175,7 @@ func TestDoNoResponse(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}


### PR DESCRIPTION
I would like to use a custom HTTP client with this library, so I have modified the library to accept an interface, instead of a specific http client implementation.