### PR TITLE
Accept an interface instead of *http.Client in WithHTTPClient

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -45,7 +45,7 @@ import (
 // Client is a client for interacting with a GraphQL API.
 type Client struct {
 	endpoint         string
-	httpClient       *http.Client
+	httpClient       HTTPClient
 	useMultipartForm bool
 
 	// closeReq will close the request body immediately allowing for reuse of client
@@ -221,10 +221,14 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	return nil
 }
 
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
 // WithHTTPClient specifies the underlying http.Client to use when
 // making requests.
 //  NewClient(endpoint, WithHTTPClient(specificHTTPClient))
-func WithHTTPClient(httpclient *http.Client) ClientOption {
+func WithHTTPClient(httpclient HTTPClient) ClientOption {
 	return func(client *Client) {
 		client.httpClient = httpclient
 	}


### PR DESCRIPTION
The WithHTTPClient helper is not really useful if you have to return a real *http.Client. Using an interface here allows us to create custom implementations that can intercept the request and whatever we need with it (such as adding headers)

(adding headers is technically feasible by using a custom Transport wrapped in a real http.Client, but that's not really recommended)